### PR TITLE
Remove SARIF results upload step from CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,9 +42,3 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
-
-    - name: Upload SARIF results
-      if: always()
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: ../results


### PR DESCRIPTION
Eliminate the upload step for SARIF results in the CodeQL analysis workflow to streamline the process.