### PR TITLE
Enforce PostgreSQL as the only supported database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ APP_ENV=development
 DEBUG=False
 FLASK_SECRET_KEY=CHANGE_ME_TO_A_SECURE_RANDOM_VALUE
 
-# Database - PostgreSQL (Blazing Fast!) or SQLite (Fallback)
+# Database - PostgreSQL (Required)
 # Format: postgresql://username:password@host:port/database
 # IMPORTANT: Use strong, unique passwords in production!
 DATABASE_URL=postgresql://YOUR_DB_USER:YOUR_STRONG_PASSWORD@localhost:5432/YOUR_DB_NAME
@@ -23,9 +23,6 @@ DATABASE_URL=postgresql://YOUR_DB_USER:YOUR_STRONG_PASSWORD@localhost:5432/YOUR_
 POSTGRES_DB=niknotes_db
 POSTGRES_USER=niknotes_user
 POSTGRES_PASSWORD=CHANGE_ME_TO_A_SECURE_PASSWORD
-
-# Automatic fallback to SQLite if PostgreSQL is unavailable
-# The app will automatically switch to: sqlite:///niknotes.db
 
 # Redis Cache (Optional - app works without it)
 # Format: redis://host:port/db

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 ## Project Overview
 **NikNotes** is an AI-powered travel packing assistant built with Flask, PostgreSQL, Redis, and Google Gemini. The app helps users create intelligent packing lists based on trip details, with weather integration and AI suggestions cached for blazing-fast responses (10-50ms).
 
-**Key architectural principle**: Performance-first design with fallback strategies (PostgreSQL → SQLite, Redis → no cache, Gemini → mock data).
+**Key architectural principle**: Performance-first design with PostgreSQL required, fallback strategies for Redis → no cache, Gemini → mock data.
 
 ## Architecture Quick Reference
 
@@ -171,7 +171,7 @@ Tuned in `docker-compose.yml`:
 **Query pattern**: Use `lazy='selectin'` for relationships (avoids N+1), eager load in repositories.
 
 ### Fallback Strategies
-- **Database**: PostgreSQL → SQLite (`data/niknotes.db`)
+- **Database**: PostgreSQL (required - no fallback)
 - **Cache**: Redis → disabled (direct API calls)
 - **AI**: Gemini → mock suggestions (`_get_mock_suggestions()`)
 - **Weather**: API → `None` (no weather in suggestions)

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV PATH=/root/.local/bin:$PATH
 # Copy application code
 COPY . .
 
-# Create directory for SQLite fallback (if needed)
+# Create data directory
 RUN mkdir -p /app/data
 
 # Create non-root user and group

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,7 @@ services:
     container_name: niknotes-web
     restart: unless-stopped
     environment:
-      # Database configuration
-      # Note: If PostgreSQL is unavailable, the app automatically falls back to SQLite (niknotes.db)
+      # Database configuration (PostgreSQL required)
       DATABASE_URL: postgresql://${POSTGRES_USER:-niknotes_user}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-niknotes_db}
       # Redis configuration
       # Note: Redis is optional - if unavailable, caching will be disabled automatically

--- a/scripts/migrations/normalize_password_nullability.py
+++ b/scripts/migrations/normalize_password_nullability.py
@@ -1,7 +1,7 @@
 """Maintenance script: Normalize password_hash nullability for legacy databases.
 
 Purpose:
-    Older SQLite/Postgres schemas may have `users.password_hash` defined as NOT NULL.
+    """\n    ⚠️ DEPRECATED: SQLite support has been removed. Use PostgreSQL with Alembic migrations.\n    \n    Ensure users.password_hash is nullable to support OAuth-only accounts.\n    Older Postgres schemas may have `users.password_hash` defined as NOT NULL.
     For OAuth / Google Sign-In users we allow it to be NULL. This script adjusts the schema.
 
 Behavior:

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -10,71 +10,49 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# Get database URL from environment or use default SQLite
-DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///niknotes.db')
-USE_POSTGRES = os.getenv('USE_POSTGRES', 'auto').lower()  # values: 'true','false','auto'
+# Get database URL from environment (PostgreSQL only)
+DATABASE_URL = os.getenv('DATABASE_URL')
+if not DATABASE_URL:
+    raise ValueError(
+        "DATABASE_URL environment variable is required. "
+        "Please set it to your PostgreSQL connection string."
+    )
 
-# Performance optimization settings
-is_postgresql = 'postgresql' in DATABASE_URL and USE_POSTGRES != 'false'
+if 'postgresql' not in DATABASE_URL:
+    raise ValueError(
+        f"Only PostgreSQL is supported. Invalid DATABASE_URL: {DATABASE_URL}"
+    )
 
-# Engine configuration for blazing fast performance
+# Engine configuration for PostgreSQL performance
 engine_config = {
     'echo': False,  # Set to True for SQL query logging
     'pool_pre_ping': True,  # Verify connections before using
     'pool_recycle': 3600,  # Recycle connections after 1 hour
+    'poolclass': QueuePool,
+    'pool_size': 20,
+    'max_overflow': 40,
+    'pool_timeout': 15,
+    'connect_args': {
+        'connect_timeout': int(os.getenv('POSTGRES_CONNECT_TIMEOUT', '5')),
+        'options': '-c statement_timeout=30000',
+        'application_name': 'niknotes_app',
+    },
+    'execution_options': {
+        'isolation_level': 'READ COMMITTED',
+    }
 }
 
-if is_postgresql:
-    # PostgreSQL-specific optimizations (shorter initial connect timeout for fast fallback)
-    engine_config.update({
-        'poolclass': QueuePool,
-        'pool_size': 20,
-        'max_overflow': 40,
-        'pool_timeout': 15,
-        'connect_args': {
-            'connect_timeout': int(os.getenv('POSTGRES_CONNECT_TIMEOUT', '3')),  # fail fast
-            'options': '-c statement_timeout=30000',
-            'application_name': 'niknotes_app',
-        },
-        'execution_options': {
-            'isolation_level': 'READ COMMITTED',
-        }
-    })
-else:
-    # SQLite-specific settings
-    engine_config['connect_args'] = {'check_same_thread': False}
-
-# Try to create engine with fallback to SQLite
-engine = None
-if is_postgresql and USE_POSTGRES != 'false':
-    try:
-        engine = create_engine(DATABASE_URL, **engine_config)
-        # Lightweight connectivity check (no stack trace on failure)
-        with engine.connect() as conn:
-            conn.execute(text('SELECT 1'))
-        print(f"✅ PostgreSQL connected: {DATABASE_URL}")
-    except Exception as e:
-        # Auto fallback only if USE_POSTGRES == 'auto'; if 'true', surface error
-        if USE_POSTGRES == 'true':
-            print(f"❌ PostgreSQL connection failed (USE_POSTGRES=true): {e}")
-            raise
-        print(f"⚠️ PostgreSQL unavailable ({type(e).__name__}: {e}). Fallback → SQLite.\n"
-              f"   Please check your DATABASE_URL and POSTGRES_PASSWORD environment variables.")
-        DATABASE_URL = 'sqlite:///niknotes.db'
-        is_postgresql = False
-        engine_config = {
-            'echo': False,
-            'pool_pre_ping': True,
-            'connect_args': {'check_same_thread': False}
-        }
-        engine = create_engine(DATABASE_URL, **engine_config)
-        print("✅ SQLite database ready: niknotes.db")
-else:
-    # Directly use SQLite
-    if 'sqlite' not in DATABASE_URL:
-        DATABASE_URL = 'sqlite:///niknotes.db'
+# Create PostgreSQL engine
+try:
     engine = create_engine(DATABASE_URL, **engine_config)
-    print("✅ SQLite database initialized")
+    # Test connectivity
+    with engine.connect() as conn:
+        conn.execute(text('SELECT 1'))
+    print(f"✅ PostgreSQL connected: {DATABASE_URL.split('@')[1] if '@' in DATABASE_URL else 'localhost'}")
+except Exception as e:
+    print(f"❌ PostgreSQL connection failed: {e}")
+    print("Please check your DATABASE_URL and ensure PostgreSQL is running.")
+    raise
 
 # Create session factory
 session_factory = sessionmaker(bind=engine)
@@ -90,38 +68,6 @@ def init_db():
     from src.database.models import Trip, PackingItem, Traveler, User
     from src.database.audit_models import AuditLog
     Base.metadata.create_all(bind=engine)
-
-    # --- Automatic SQLite schema patch for newly added columns (OAuth/Google Sign-In) ---
-    # Problem: Existing local niknotes.db created before adding oauth columns -> OperationalError.
-    # Strategy: For SQLite only, detect missing columns in 'users' table and ALTER TABLE to add them.
-    # Safe because ALTER TABLE ADD COLUMN in SQLite does not rewrite existing data and new columns are nullable.
-    if not is_postgresql and engine is not None:
-        try:
-            with engine.connect() as conn:
-                # Get existing column names
-                result = conn.execute(text("PRAGMA table_info(users)"))
-                existing_cols = {row[1] for row in result.fetchall()}
-                required_cols = {
-                    'oauth_provider': "ALTER TABLE users ADD COLUMN oauth_provider VARCHAR(50)",
-                    'oauth_id': "ALTER TABLE users ADD COLUMN oauth_id VARCHAR(255)",
-                    'profile_picture': "ALTER TABLE users ADD COLUMN profile_picture VARCHAR(500)"
-                }
-                added = []
-                for col, stmt in required_cols.items():
-                    if col not in existing_cols:
-                        conn.execute(text(stmt))
-                        added.append(col)
-                # Create composite index if missing (check sqlite_master)
-                if 'oauth_provider' in existing_cols or 'oauth_provider' in added:
-                    idx_check = conn.execute(text("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_user_oauth'"))
-                    if not idx_check.fetchone():
-                        conn.execute(text("CREATE INDEX idx_user_oauth ON users(oauth_provider, oauth_id)"))
-                        added.append('idx_user_oauth')
-                if added:
-                    print(f"🔧 SQLite schema auto-patch applied: {', '.join(added)}")
-        except Exception as e:
-            # Non-fatal: continue without patch (login will still fail, but we surface message)
-            print(f"⚠️ SQLite schema patch failed: {e}")
 
 
 def get_session():


### PR DESCRIPTION
Remove SQLite fallback and related configurations, ensuring PostgreSQL is required for the application. Update documentation and code to reflect this change.